### PR TITLE
Checking for adapter's native createParamAccessor

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function createParameterContext (queryable) {
   if (!(anyDbAdapter && anyDbAdapter.name)) {
     throw new TypeError('Argument must be a valid Queryable');
   }
-  var impl = exports.adapters[anyDbAdapter.name];
+  var impl = adapter.createParamAccessor || exports.adapters[anyDbAdapter.name];
 
   if (!impl) {
     throw new Error('The ' + anyDbAdapter.name + ' adapter is not yet supported');

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function createParameterContext (queryable) {
   if (!(anyDbAdapter && anyDbAdapter.name)) {
     throw new TypeError('Argument must be a valid Queryable');
   }
-  var impl = adapter.createParamAccessor || exports.adapters[anyDbAdapter.name];
+  var impl = anyDbAdapter.createParamAccessor || exports.adapters[anyDbAdapter.name];
 
   if (!impl) {
     throw new Error('The ' + anyDbAdapter.name + ' adapter is not yet supported');


### PR DESCRIPTION
This change makes node-any-db-params check for adapter's native `createParamAccessor()`, as discussed on https://github.com/grncdr/node-any-db-adapter-spec/pull/7#issuecomment-57315898. If there is any, it will be used instead of this modules' implementation.
